### PR TITLE
feat: support custom Base URL and Model ID (#8)

### DIFF
--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -24,6 +24,7 @@ pub enum ApiError {
     NoImageGenerated,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Model {
     #[serde(rename = "nano-banana")]
@@ -179,6 +180,7 @@ struct GeminiError {
 pub struct NanoBananaClient {
     client: Client,
     api_key: String,
+    base_url: String,
 }
 
 impl NanoBananaClient {
@@ -186,6 +188,15 @@ impl NanoBananaClient {
         Self {
             client: Client::new(),
             api_key,
+            base_url: "https://generativelanguage.googleapis.com/v1beta".to_string(),
+        }
+    }
+
+    pub fn with_base_url(api_key: String, base_url: String) -> Self {
+        Self {
+            client: Client::new(),
+            api_key,
+            base_url,
         }
     }
 
@@ -197,18 +208,18 @@ impl NanoBananaClient {
     /// * `image_base64` - The cropped source image as base64
     /// * `mask_base64` - The mask image as base64 (white = generate, black = keep)
     /// * `reference_images` - Optional reference images to guide generation
+    /// * `custom_base_url` - Optional custom base URL override
     pub async fn generate_fill(
         &self,
-        model: Model,
+        model: &str,
         prompt: &str,
         image_base64: &str,
         mask_base64: &str,
         reference_images: &[&str],
     ) -> Result<String, ApiError> {
-        let model_name = model.to_gemini_model();
         let url = format!(
-            "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent?key={}",
-            model_name, self.api_key
+            "{}/models/{}:generateContent?key={}",
+            self.base_url, model, self.api_key
         );
 
         // Build parts array starting with source image and mask
@@ -284,7 +295,7 @@ impl NanoBananaClient {
         };
 
         // Send request
-        log::info!("Sending request to Gemini API: {}", model_name);
+        log::info!("Sending request to Gemini API: {}", model);
         
         let response = self
             .client

--- a/src-tauri/src/commands/generate.rs
+++ b/src-tauri/src/commands/generate.rs
@@ -1,7 +1,7 @@
 // BananaSlice - Generation Commands
 // Tauri commands for AI image generation
 
-use crate::api::{Model, NanoBananaClient};
+use crate::api::NanoBananaClient;
 use crate::keystore;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use serde::{Deserialize, Serialize};
@@ -16,6 +16,8 @@ pub struct GenerateRequest {
     pub mask_base64: String,
     #[serde(default)]
     pub reference_images: Vec<String>, // Optional reference images as base64
+    #[serde(default)]
+    pub base_url: Option<String>, // Optional custom base URL
 }
 
 #[derive(Debug, Serialize)]
@@ -66,20 +68,24 @@ pub async fn generate_fill(request: GenerateRequest) -> GenerateResponse {
         }
     };
 
-    // Parse model
-    let model = match request.model.as_str() {
-        "nano-banana-pro" => Model::NanoBananaPro,
-        "nano-banana" | _ => Model::NanoBanana,
+    // Resolve model name: known aliases map to Gemini models, otherwise use as-is
+    let model_name = match request.model.as_str() {
+        "nano-banana-pro" => "gemini-3-pro-image-preview",
+        "nano-banana" => "gemini-2.5-flash-image",
+        custom => custom, // Allow custom model IDs
     };
 
-    // Create client and make request
-    let client = NanoBananaClient::new(api_key);
+    // Create client with optional custom base URL
+    let client = match &request.base_url {
+        Some(base_url) if !base_url.is_empty() => NanoBananaClient::with_base_url(api_key, base_url.clone()),
+        _ => NanoBananaClient::new(api_key),
+    };
     
     // Convert reference images to &str slices
     let ref_images: Vec<&str> = request.reference_images.iter().map(|s| s.as_str()).collect();
     
     match client
-        .generate_fill(model, &request.prompt, &request.image_base64, &request.mask_base64, &ref_images)
+        .generate_fill(model_name, &request.prompt, &request.image_base64, &request.mask_base64, &ref_images)
         .await
     {
         Ok(image_base64) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,7 @@ function App() {
     const { activeSelection } = useSelectionStore();
     const { setBaseLayer } = useLayerStore();
     const { undo: handleUndo, redo: handleRedo, canUndo, canRedo, reset: resetHistory } = useHistoryStore();
-    const { setDefaultModel: setModel } = useSettingsStore();
+    const { setDefaultModel: setModel, customModel } = useSettingsStore();
     const { recentFiles } = useRecentFilesStore();
 
     // Custom hooks
@@ -358,10 +358,17 @@ function App() {
 
                             <div className="model-selector">
                                 <label className="input-label">Model</label>
-                                <select className="select-input" value={model} onChange={(e) => setModel(e.target.value as AIModel)}>
-                                    <option value="nano-banana-pro">Nano Banana Pro</option>
-                                    <option value="nano-banana">Nano Banana (Fast)</option>
-                                </select>
+                                {customModel ? (
+                                    <div className="api-key-status" style={{ padding: 'var(--spacing-sm) var(--spacing-md)', background: 'var(--bg-input)', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border-medium)', fontSize: 'var(--font-size-sm)' }}>
+                                        <span className="status-configured">✓ {customModel}</span>
+                                        <span style={{ color: 'var(--text-secondary)', marginLeft: '8px' }}>(custom)</span>
+                                    </div>
+                                ) : (
+                                    <select className="select-input" value={model} onChange={(e) => setModel(e.target.value as AIModel)}>
+                                        <option value="nano-banana-pro">Nano Banana Pro</option>
+                                        <option value="nano-banana">Nano Banana (Fast)</option>
+                                    </select>
+                                )}
                             </div>
 
                             <ReferenceImages

--- a/src/api/generate.ts
+++ b/src/api/generate.ts
@@ -8,6 +8,7 @@ export interface GenerateRequest {
     image_base64: string;
     mask_base64: string;
     reference_images?: string[]; // Optional reference images as base64
+    base_url?: string; // Optional custom API base URL
 }
 
 export interface GenerateResponse {
@@ -45,14 +46,17 @@ export async function generateFill(
     prompt: string,
     imageBase64: string,
     maskBase64: string,
-    referenceImages: string[] = []
+    referenceImages: string[] = [],
+    baseUrl: string = '',
+    customModel: string = ''
 ): Promise<GenerateResponse> {
     const request: GenerateRequest = {
-        model,
+        model: customModel || model,
         prompt,
         image_base64: imageBase64,
         mask_base64: maskBase64,
         reference_images: referenceImages,
+        base_url: baseUrl || undefined,
     };
 
     return invoke<GenerateResponse>('generate_fill', { request });

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,6 +1,7 @@
 // Settings Modal Component
 import { useState, useEffect } from 'react';
 import { setApiKey, hasApiKey, deleteApiKey } from '../api';
+import { useSettingsStore } from '../store/settingsStore';
 import { Tooltip } from './Tooltip';
 import { open } from '@tauri-apps/plugin-shell';
 import './Modal.css';
@@ -15,6 +16,11 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     const [hasKey, setHasKey] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
     const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+    const baseUrl = useSettingsStore((s) => s.baseUrl);
+    const customModel = useSettingsStore((s) => s.customModel);
+    const setBaseUrl = useSettingsStore((s) => s.setBaseUrl);
+    const setCustomModel = useSettingsStore((s) => s.setCustomModel);
 
     useEffect(() => {
         if (isOpen) {
@@ -147,6 +153,40 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                 {message.text}
                             </div>
                         )}
+                    </div>
+
+                    <div className="settings-section" style={{ marginTop: '24px' }}>
+                        <h3>Custom API Endpoint</h3>
+                        <p className="settings-description">
+                            Configure a custom Gemini-compatible API endpoint. Leave empty to use the default Google API.
+                        </p>
+
+                        <label className="input-label" style={{ display: 'block', marginBottom: '6px', fontSize: 'var(--font-size-sm)', color: 'var(--text-secondary)' }}>
+                            Base URL
+                        </label>
+                        <input
+                            type="text"
+                            placeholder="https://generativelanguage.googleapis.com/v1beta"
+                            value={baseUrl}
+                            onChange={(e) => setBaseUrl(e.target.value)}
+                            className="api-key-input"
+                            style={{ width: '100%', boxSizing: 'border-box', marginBottom: '12px' }}
+                        />
+
+                        <label className="input-label" style={{ display: 'block', marginBottom: '6px', fontSize: 'var(--font-size-sm)', color: 'var(--text-secondary)' }}>
+                            Custom Model ID
+                        </label>
+                        <input
+                            type="text"
+                            placeholder="e.g. gemini-2.5-flash-image (leave empty for default)"
+                            value={customModel}
+                            onChange={(e) => setCustomModel(e.target.value)}
+                            className="api-key-input"
+                            style={{ width: '100%', boxSizing: 'border-box' }}
+                        />
+                        <p className="settings-description" style={{ marginTop: '6px' }}>
+                            When set, this overrides the model selector in the main panel.
+                        </p>
                     </div>
                 </div>
             </div>

--- a/src/hooks/useGeneration.ts
+++ b/src/hooks/useGeneration.ts
@@ -46,7 +46,7 @@ export function useGeneration({ prompt, referenceImages, onOpenSettings }: UseGe
     const { activeSelection, processForAPI, clearSelection, setActiveSelection } = useSelectionStore();
     const { addLayer, getVisibleLayers } = useLayerStore();
     const { setActiveTool } = useToolStore();
-    const { defaultModel: model } = useSettingsStore();
+    const { defaultModel: model, baseUrl, customModel } = useSettingsStore();
 
     // Create progress stages based on current stage
     const getProgressStages = (): ProgressStage[] => {
@@ -109,7 +109,9 @@ export function useGeneration({ prompt, referenceImages, onOpenSettings }: UseGe
                 prompt,
                 processed.croppedImageBase64,
                 processed.maskBase64,
-                referenceImages.filter(img => img !== '')
+                referenceImages.filter(img => img !== ''),
+                baseUrl,
+                customModel
             );
 
             if (!genResult.success || !genResult.image_base64) {

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -12,9 +12,15 @@ interface SettingsState {
     // Default model
     defaultModel: AIModel;
 
+    // Custom API configuration
+    baseUrl: string;
+    customModel: string;
+
     // Actions
     setApiKeySet: (set: boolean) => void;
     setDefaultModel: (model: AIModel) => void;
+    setBaseUrl: (url: string) => void;
+    setCustomModel: (model: string) => void;
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -23,16 +29,22 @@ export const useSettingsStore = create<SettingsState>()(
             // Initial state
             apiKeySet: false,
             defaultModel: 'nano-banana-pro',
+            baseUrl: '',
+            customModel: '',
 
             // Actions
             setApiKeySet: (apiKeySet) => set({ apiKeySet }),
             setDefaultModel: (defaultModel) => set({ defaultModel }),
+            setBaseUrl: (baseUrl) => set({ baseUrl }),
+            setCustomModel: (customModel) => set({ customModel }),
         }),
         {
             name: 'bananaslice-settings',
             partialize: (state) => ({
                 defaultModel: state.defaultModel,
                 apiKeySet: state.apiKeySet,
+                baseUrl: state.baseUrl,
+                customModel: state.customModel,
             }),
         }
     )

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -74,6 +74,7 @@ export interface GenerationRequest {
     prompt: string;
     imageBase64: string;
     maskBase64: string;
+    baseUrl?: string;
 }
 
 // Canvas state


### PR DESCRIPTION
Add support for configurable Gemini-compatible API endpoints:
- Now accepts custom base_url and model strings
- Code are modified using opencode and deepseek
- Have tested using api key from [aihubmix](https://aihubmix.com)


<img width="1074" height="749" alt="image" src="https://github.com/user-attachments/assets/5e7351ae-97af-4170-868f-5f2fc3e64334" />
